### PR TITLE
feat: add Filament v4/v5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "homepage": "https://github.com/15web/filament-tree",
     "require": {
         "php": "^8.2",
-        "filament/support": "^3.2",
+        "filament/support": "^3.2 || ^4.0 || ^5.0",
         "illuminate/contracts": "^11.0 || ^12.0",
         "kalnoy/nestedset": "^6.0.5",
         "spatie/laravel-package-tools": "^1.14.0"

--- a/src/Components/Header.php
+++ b/src/Components/Header.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Kalnoy\Nestedset\QueryBuilder;
 use Livewire\Component;
-use Livewire\Features\SupportEvents\Event;
 use Studio15\FilamentTree\Components\Form\ParentSelect;
 
 /**
@@ -34,7 +33,7 @@ final class Header extends Component implements HasForms, HasActions
         $model = $this->component::getModel();
 
         $action = CreateAction::make()
-            ->after(fn (): Event => $this->dispatch('filament-tree-updated'));
+            ->after(fn () => $this->dispatch('filament-tree-updated'));
 
         $this->configureAction($action);
 

--- a/src/Components/Row.php
+++ b/src/Components/Row.php
@@ -21,7 +21,6 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Session;
 use Livewire\Component;
-use Livewire\Features\SupportEvents\Event;
 use RuntimeException;
 use Studio15\FilamentTree\Components\Form\ParentSelect;
 
@@ -119,7 +118,7 @@ final class Row extends Component implements HasForms, HasActions, HasInfolists
                 }
             })
             ->record(fn (array $arguments): Model => $this->row)
-            ->after(fn (): Event => $this->dispatch('filament-tree-updated'))
+            ->after(fn () => $this->dispatch('filament-tree-updated'))
             ->icon('heroicon-m-trash')
             ->labeledFrom('md');
     }

--- a/src/FilamentTreePlugin.php
+++ b/src/FilamentTreePlugin.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio15\FilamentTree;
+
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+use Filament\Support\Assets\Css;
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
+use Livewire\Livewire;
+use Studio15\FilamentTree\Components\Footer;
+use Studio15\FilamentTree\Components\Header;
+use Studio15\FilamentTree\Components\Move;
+use Studio15\FilamentTree\Components\Row;
+
+final class FilamentTreePlugin implements Plugin
+{
+    public function getId(): string
+    {
+        return FilamentTreeServiceProvider::$name;
+    }
+
+    public function register(Panel $panel): void
+    {
+        //
+    }
+
+    public function boot(Panel $panel): void
+    {
+        Livewire::component('filament-tree::move', Move::class);
+        Livewire::component('filament-tree::row', Row::class);
+        Livewire::component('filament-tree::header', Header::class);
+        Livewire::component('filament-tree::footer', Footer::class);
+
+        FilamentAsset::register([
+            Css::make('filament-tree', __DIR__.'/../resources/dist/filament-tree.min.css')->loadedOnRequest(),
+            Js::make('filament-tree', __DIR__.'/../resources/dist/filament-tree.min.js')->loadedOnRequest(),
+            Js::make('sortable', 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js')->loadedOnRequest(),
+        ], package: '15web/filament-tree');
+    }
+
+    public static function make(): static
+    {
+        return app(static::class);
+    }
+
+    public static function get(): static
+    {
+        return filament(app(static::class)->getId());
+    }
+}

--- a/src/FilamentTreeServiceProvider.php
+++ b/src/FilamentTreeServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio15\FilamentTree;
 
+use Filament\Panel;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
@@ -54,5 +55,14 @@ final class FilamentTreeServiceProvider extends PackageServiceProvider
             Js::make('filament-tree', __DIR__.'/../resources/dist/filament-tree.min.js')->loadedOnRequest(),
             Js::make('sortable', 'https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js')->loadedOnRequest(),
         ], package: self::$name);
+
+        // Register the plugin with Filament panels (v4+ only)
+        if (method_exists(Panel::class, 'configureUsing')) {
+            Panel::configureUsing(function (Panel $panel): void {
+                if (! $panel->hasPlugin(self::$name)) {
+                    $panel->plugin(FilamentTreePlugin::make());
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
- Update composer.json constraint to allow ^3.2 || ^4.0 || ^5.0
- Add FilamentTreePlugin implementing Filament\Contracts\Plugin for v4+ panel integration
- Auto-register plugin with panels via Panel::configureUsing (v4+ only, guarded by method_exists)
- Remove Event return type hints from closures for Livewire v4 compatibility